### PR TITLE
ci: run the AWS SAM installer as root and deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ jobs:
       - run: >-
           wget https://github.com/aws/aws-sam-cli/releases/download/sam-cli-beta-cdk/aws-sam-cli-linux-x86_64.zip -P /tmp/
           && unzip /tmp/aws-sam-cli-linux-x86_64.zip -d /tmp/sam-installation
-          && /tmp/sam-installation/install
+          && sudo /tmp/sam-installation/install
       - run: sam-beta-cdk build
-      - run: sam deploy
-      - run: cdk deploy -a .aws-sam/build
+      - run: cdk deploy -a .aws-sam/build --require-approval=never


### PR DESCRIPTION
Update the CD pipeline to run the AWS SAM installer as root, and deploy the Lambda function to the development environment by using `cdk deploy`, instead of `sam deploy`.