### PR TITLE
ci: add Lambda tests to CI pipeline, do cleanup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,8 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  tests:
-    name: Run Jest tests
+  cdk_tests:
+    name: Run the CDK stack unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +32,22 @@ jobs:
           node-version: 14
       - run: npm install
       - run: npm test
+      - name: Upload coverage information
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: coverage/
+
+  lambda_tests:
+    name: Run the Lambda function unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 14
+      - run: npm --prefix ./lambda/ses-password-lambda install
+      - run: npm --prefix ./lambda/ses-password-lambda test
       - name: Upload coverage information
         uses: actions/upload-artifact@v2
         with:
@@ -65,32 +81,45 @@ jobs:
         with:
           name: cdk.out
           path: cdk.out
-      - uses: stelligent/cfn_nag@master
+      - name: Run cfn_nag
+        uses: stelligent/cfn_nag@master
         with:
           input_path: cdk.out
 
   taskcat:
     name: Run taskcat tests
     runs-on: ubuntu-latest
-    needs: [cdk_synth]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
       - uses: actions/setup-node@v2.1.4
         with:
           node-version: 14
-      - run: npm install -g aws-cdk typescript ts-node
-      - run: npm install
-      - run: npm --prefix ./lambda/ses-password-lambda install --production=true
-      - run: npm run build
-      - run: cdk synth "*" --context isTaskcatRun=true --output cdk.out
-      - uses: actions/setup-python@v2
-      - name: Configure AWS Credentials
+
+      - name: Install the AWS CDK and TypeScript packages
+        run: npm install -g aws-cdk typescript ts-node
+
+      - name: Install Node dependencies for the CDK stack
+        run: npm install
+
+      - name: Install Node dependencies for the Lambda function
+        run: npm --prefix ./lambda/ses-password-lambda install --production=true
+
+      - name: Build the CDK stack
+        run: npm run build
+
+      - name: Synthesize the CloudFormation template
+        run: cdk synth "*" --context isTaskcatRun=true --output cdk.out
+
+      - name: Configure the AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
-      - uses: ShahradR/action-taskcat@v2
+
+      - name: Run the taskcat tests
+        uses: ShahradR/action-taskcat@v2
         with:
           commands: test run
           update_taskcat: true
@@ -99,7 +128,8 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, vale, tests, cdk_synth, cfn_nag, taskcat]
+    needs:
+      [pre-commit, vale, cdk_tests, lambda_tests, cdk_synth, cfn_nag, taskcat]
     if: ${{ needs.pre-commit.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a new CI pipeline job to run the Lambda function's Jest tests, and add names to some of the job's steps.